### PR TITLE
Remove <ScrollView> or pass in scrollEnabled prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import {
     View,
-    ScrollView,
     Alert
 } from 'react-native'
 
@@ -69,10 +68,7 @@ export default class MultiStep extends Component {
         
         return (
             <View>
-                <ScrollView>
                    {this.state.steplist[this.state.curState]}
-                    
-                </ScrollView>
             </View>
         )
             


### PR DESCRIPTION
Great component! : ) 
Nevertheless, I had to remove ScrollView in order for my form components to stay fixed. Otherwise, any minimal vertical movement would trigger the vertical scroll which is not something desirable, especially with a range select component. I would propose removing ScrollView or allowing the scrollEnabled prop to be passed in, so that it's possible to create fixed position forms.