### PR TITLE
Passing the props to the children

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ export default class MultiStep extends Component {
                 nextFn:this.next,
                 prevFn:this.previous,
                 saveState:this.saveStepState,
-                getState:this.getStepState
+                getState:this.getStepState,
+                ...this.props
             })
             
             


### PR DESCRIPTION
Using the HOC pattern, is necessary pass the props to the child components.