### PR TITLE
Fix wrong typo 'comonent'->'component' at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## How to use
 
-### In the top level comonenet add
+### In the top level componenet add
 
 ```
 import MultiStep from 'react-native-multistep-wizard'


### PR DESCRIPTION
Fix wrong typo 'comonent'->'component' at README